### PR TITLE
chore: gitignore java/target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ c/qrcodegen-worker
 c/qrcodegen-worker.exe
 c/qrcodegen-worker.o
 c/qrcodegen.o
+java/target/


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/17800

I trust the Copilot that it's safe:

<img width="622" alt="image" src="https://github.com/user-attachments/assets/791c0fbc-7c76-4b5e-b71b-ab348271d83c" />
